### PR TITLE
fix: Add ReattachUserDataAsync for Jellyfin 10.11.6 compatibility

### DIFF
--- a/Decorators/ItemRepositoryDecorator.cs
+++ b/Decorators/ItemRepositoryDecorator.cs
@@ -159,4 +159,7 @@ public sealed class GelatoItemRepository : IItemRepository
     public IReadOnlyDictionary<string, MusicArtist[]> FindArtists(
         IReadOnlyList<string> artistNames
     ) => _inner.FindArtists(artistNames);
+
+    public Task ReattachUserDataAsync(BaseItem item, CancellationToken cancellationToken) =>
+        _inner.ReattachUserDataAsync(item, cancellationToken);
 }


### PR DESCRIPTION
Jellyfin 10.11.6 added the ReattachUserDataAsync method to the IItemRepository interface. This causes the plugin to fail with:

  Method 'ReattachUserDataAsync' in type 'Gelato.Decorators.GelatoItemRepository'
  does not have an implementation.

Add the missing method delegation to fix plugin loading.