### PR TITLE
Refactor IsValid method for URL validation to enable P2P streaming without debrid

### DIFF
--- a/GelatoStremioProvider.cs
+++ b/GelatoStremioProvider.cs
@@ -694,16 +694,21 @@ namespace Gelato
         }
 
         public bool IsValid()
-{
-    if (string.IsNullOrWhiteSpace(Url))
-        return false;
-
-    Uri uri;
-    if (!Uri.TryCreate(Url, UriKind.Absolute, out uri))
-        return false;
-
-    return !(uri.PathAndQuery == "/" || string.IsNullOrEmpty(uri.PathAndQuery));
-}
+        {
+            // P2P torrent streams have an infohash but no URL —
+            // they are streamed via the internal /gelato/stream endpoint
+            if (IsTorrent() && !IsFile())
+                return true;
+        
+            if (string.IsNullOrWhiteSpace(Url))
+                return false;
+        
+            Uri uri;
+            if (!Uri.TryCreate(Url, UriKind.Absolute, out uri))
+                return false;
+        
+            return !(uri.PathAndQuery == "/" || string.IsNullOrEmpty(uri.PathAndQuery));
+        }
 
         public bool IsFile()
         {


### PR DESCRIPTION
<html><head></head><body><h1>fix: Allow P2P (infohash-only) streams to pass <code>IsValid()</code> check</h1>
<h2>Note</h2>
This hasn't been tested as I don't have a compiler or sure how to locally install the plugin but theoretically should work - let me know how to test and I can though
<h2>Problem</h2>
<p>P2P streams from Torrentio (via AIOStreams) are all rejected by <code>StremioStream.IsValid()</code> with the log message:</p>
<pre><code>[WRN] Gelato.GelatoManager: Invalid stream, skipping [P2P] Torrentio 1080p
</code></pre>
<p><code>IsValid()</code> requires a valid absolute URL in the <code>Url</code> property, but P2P torrent streams don't have a <code>Url</code> — they only have an <code>InfoHash</code> (and <code>Sources</code>/trackers). Example response from AIOStreams for a P2P stream:</p>
<pre><code class="language-json">{
  "name": "[P2P] Torrentio 2160p",
  "infoHash": "10c93a2ad69b9c576a5de6f9495b266fc992c889",
  "fileIdx": 0,
  "sources": ["tracker:udp://tracker.opentrackr.org:1337/announce", ...],
  "behaviorHints": {
    "bingeGroup": "...",
    "videoSize": 92502858138,
    "filename": "Inception.2010.2160p.UHD.BDRemux.mkv"
  }
}
</code></pre>
<p>Note: no <code>url</code> field. The <code>Url</code> property defaults to <code>""</code>, so <code>IsValid()</code> immediately returns <code>false</code>. This means the P2P streaming path in <code>GelatoManager</code> (which builds <code>http://127.0.0.1:{httpPort}/gelato/stream?ih=...</code>) and the <code>GelatoApiController</code> MonoTorrent integration are unreachable.</p>
<h2>Fix</h2>
<p>Use the existing <code>IsTorrent()</code> and <code>IsFile()</code> helpers to accept pure P2P streams while preserving full URL validation for debrid/HTTP streams:</p>
<pre><code class="language-csharp">public bool IsValid()
{
    // P2P torrent streams have an infohash but no URL —
    // they are streamed via the internal /gelato/stream endpoint
    if (IsTorrent() &amp;&amp; !IsFile())
        return true;

    if (string.IsNullOrWhiteSpace(Url))
        return false;

    Uri uri;
    if (!Uri.TryCreate(Url, UriKind.Absolute, out uri))
        return false;

    return !(uri.PathAndQuery == "/" || string.IsNullOrEmpty(uri.PathAndQuery));
}
</code></pre>
<p><strong>Behaviour matrix:</strong></p>

Stream type | IsTorrent() | IsFile() | Result
-- | -- | -- | --
Pure P2P (infohash only, no URL) | true | false | ✅ Valid (new)
Debrid (URL only, no infohash) | false | true | Falls through to URL validation (unchanged)
Debrid + infohash (both populated) | true | true | Falls through to URL validation (unchanged)
Neither (broken stream) | false | false | ❌ Invalid (unchanged)


<h2>Reproduction</h2>
<ol>
<li>Set up AIOStreams with Torrentio enabled, <strong>no debrid service</strong> configured</li>
<li>Install Gelato, enable P2P in plugin settings</li>
<li>Search for any movie — streams are found but all logged as "Invalid stream, skipping"</li>
<li>0 playable streams result</li>
</ol>
<h2>Environment</h2>
<ul>
<li>Gelato v0.25.7.0</li>
<li>Jellyfin 10.11</li>
<li>AIOStreams (self-hosted)</li>
<li>Torrentio addon (P2P only, no debrid)</li>
</ul></body></html>