### PR TITLE
fix: restore .strm support with parent hierarchy fix and repository guards

### DIFF
--- a/ScheduledTasks/PurgeStreams.cs
+++ b/ScheduledTasks/PurgeStreams.cs
@@ -80,22 +80,28 @@ namespace Gelato.Tasks {
 
             int done = 0;
 
-            foreach (var item in streams) {
-                cancellationToken.ThrowIfCancellationRequested();
+            try {
+                Gelato.Decorators.GelatoItemRepository.SuppressGuard = true;
+                foreach (var item in streams) {
+                    cancellationToken.ThrowIfCancellationRequested();
 
-                try {
-                    _library.DeleteItem(
-            item,
-            new DeleteOptions { DeleteFileLocation = true },
-            true);
-                }
-                catch (Exception ex) {
-                    _log.LogWarning(ex, "Failed to delete item {ItemId}", item.Id);
-                }
+                    try {
+                        _library.DeleteItem(
+                item,
+                new DeleteOptions { DeleteFileLocation = true },
+                true);
+                    }
+                    catch (Exception ex) {
+                        _log.LogWarning(ex, "Failed to delete item {ItemId}", item.Id);
+                    }
 
-                done++;
-                var pct = Math.Min(100.0, ((double)done / total) * 100.0);
-                progress?.Report(pct);
+                    done++;
+                    var pct = Math.Min(100.0, ((double)done / total) * 100.0);
+                    progress?.Report(pct);
+                }
+            }
+            finally {
+                Gelato.Decorators.GelatoItemRepository.SuppressGuard = false;
             }
 
             progress?.Report(100.0);


### PR DESCRIPTION
This PR restores .strm support with several critical fixes:\n- Corrects the parent hierarchy mismatch by parenting stream items to movie subfolders.\n- Adds a repository-level guard to prevent the library scanner from deleting should-stay stream items.\n- Implements stale record cleanup in SaveItemsStrm when the path/ID changes.\n- Handles duplicate guid crashes via GroupBy in SyncStreams.