### PR TITLE
Fix NullReferenceException when MediaSourceInfo.Path is null

### DIFF
--- a/Decorators/MediaSourceManagerDecorator.cs
+++ b/Decorators/MediaSourceManagerDecorator.cs
@@ -255,8 +255,8 @@ public sealed class MediaSourceManagerDecorator(
         {
             // remove primary from list when there are streams
             sources = sources
-                .Where(k => !k.Path.StartsWith("gelato", StringComparison.OrdinalIgnoreCase))
-                .Where(k => !k.Path.StartsWith("stremio", StringComparison.OrdinalIgnoreCase))
+                .Where(k => !(k.Path?.StartsWith("gelato", StringComparison.OrdinalIgnoreCase) ?? false))
+                .Where(k => !(k.Path?.StartsWith("stremio", StringComparison.OrdinalIgnoreCase) ?? false))
                 .ToList();
         }
 


### PR DESCRIPTION
Two chained Where predicates in GetStaticMediaSources call .StartsWith() directly on k.Path without a null check. When any MediaSourceInfo has a null Path, this throws a NullReferenceException. Replaced with null-conditional operators to handle this safely.

Thanks for your patience, I appreciate it.