### PR TITLE
Fix catalog importer

### DIFF
--- a/Config/ConfigurationHelper.cs
+++ b/Config/ConfigurationHelper.cs
@@ -1,0 +1,17 @@
+namespace Gelato.Config
+{
+    internal static class ConfigurationHelper
+    {
+        public static CatalogConfig? GetCatalogConfig(string id, string type)
+        {
+            return GelatoPlugin.Instance!.Configuration.Catalogs.FirstOrDefault(c =>
+                c.Id == id && c.Type == type
+            );
+        }
+
+        public static PluginConfiguration GetConfig(Guid? userId = null)
+        {
+            return GelatoPlugin.Instance!.GetConfig(userId ?? Guid.Empty);
+        }
+    }
+}

--- a/GelatoManager.cs
+++ b/GelatoManager.cs
@@ -102,29 +102,15 @@ public sealed class GelatoManager(
 
     public Folder? TryGetMovieFolder(Guid userId)
     {
-        return TryGetFolder(
-            GelatoPlugin.Instance!.Configuration.GetEffectiveConfig(userId).MoviePath
-        );
+        return TryGetConfigFolder(GelatoPlugin.Instance!.Configuration.GetEffectiveConfig(userId).MoviePath);
     }
 
     public Folder? TryGetSeriesFolder(Guid userId)
     {
-        return TryGetFolder(
-            GelatoPlugin.Instance!.Configuration.GetEffectiveConfig(userId).SeriesPath
-        );
+        return TryGetConfigFolder(GelatoPlugin.Instance!.Configuration.GetEffectiveConfig(userId).SeriesPath);
     }
 
-    public Folder? TryGetMovieFolder(PluginConfiguration cfg)
-    {
-        return TryGetFolder(cfg.MoviePath);
-    }
-
-    public Folder? TryGetSeriesFolder(PluginConfiguration cfg)
-    {
-        return TryGetFolder(cfg.SeriesPath);
-    }
-
-    private Folder? TryGetFolder(string path)
+    public Folder? TryGetConfigFolder(string path)
     {
         if (string.IsNullOrWhiteSpace(path))
         {

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -85,8 +85,19 @@ public class GelatoPlugin : BasePlugin<PluginConfiguration>, IHasWebPages
                     }
                     var stremio = _stremioFactory.Create(cfg);
                     cfg.Stremio = stremio;
-                    cfg.MovieFolder = _manager.TryGetMovieFolder(cfg);
-                    cfg.SeriesFolder = _manager.TryGetSeriesFolder(cfg);
+
+                    cfg.MovieFolder = _manager.TryGetConfigFolder(cfg.MoviePath);
+                    if (cfg.MovieFolder is null)
+                    {
+                        _log.LogError($"Unable to retrieve movie folder for user '{userId}', Gelato will not be able to function properly! Please add the path for defined in Gelato setting to a library, start a library scan and restart Jellyfin.");
+                    }
+
+                    cfg.SeriesFolder = _manager.TryGetConfigFolder(cfg.SeriesPath);
+                    if (cfg.SeriesFolder is null)
+                    {
+                        _log.LogError($"Unable to retrieve series folder for user '{userId}', Gelato will not be able to function properly! Please add the path for defined in Gelato setting to a library, start a library scan and restart Jellyfin.");
+                    }
+
                     return cfg;
                 }
             );

--- a/Services/CatalogService.cs
+++ b/Services/CatalogService.cs
@@ -74,11 +74,4 @@ public class CatalogService(GelatoStremioProviderFactory stremioFactory)
 
         GelatoPlugin.Instance.SaveConfiguration();
     }
-
-    public CatalogConfig? GetCatalogConfig(string id, string type)
-    {
-        return GelatoPlugin.Instance!.Configuration.Catalogs.FirstOrDefault(c =>
-            c.Id == id && c.Type == type
-        );
-    }
 }


### PR DESCRIPTION
Fix catalog import:
- Collections not getting created or updated
- Collection getting recreated instead of updated
- Collection overwriting themself
- No safeguards for catalogs having less item than configured and constantly looping over the same items
- No checks for existing items in the collection, leading to the same items getting imported and the collection not progressing
- Import will now only stop after having imported reaching the configured amount for actual new items added to it
- Every catalog in the settings will get it's own collection (e.g. Netflix -> Netflix movies & Netflix series)
- Minor changes