### PR TITLE
Fix filter scoping for Home Screen Sections queries

### DIFF
--- a/Decorators/ItemRepositoryDecorator.cs
+++ b/Decorators/ItemRepositoryDecorator.cs
@@ -45,8 +45,14 @@ public sealed class GelatoItemRepository(IItemRepository inner, IHttpContextAcce
         var ctx = _http.HttpContext;
         var filterUnreleased = GelatoPlugin.Instance!.Configuration.FilterUnreleased;
         var bufferDays = GelatoPlugin.Instance.Configuration.FilterUnreleasedBufferDays;
+        var isSingleItemQuery = filter.ItemIds is { Length: 1 };
 
-        if (ctx is not null && !ctx.IsSingleItemList() && filter.IsDeadPerson is null)
+        if (
+            ctx is not null
+            && ctx.IsApiListing()
+            && !isSingleItemQuery
+            && filter.IsDeadPerson is null
+        )
         {
             filter.IsDeadPerson = null;
             if (


### PR DESCRIPTION
I tracked this to the filter guard in `GelatoItemRepository.ApplyFilters`.

This regression appears tied to commit `1cb8d57` (`refactor: filter out streams on everything except single item queries`), which changed the guard to rely on `IsSingleItemList()`.

The old check used `!ctx.IsSingleItemList()`, and `IsSingleItemList()` depends on this block in `Common.cs`:

~~~csharp
var q = ctx.Request.Query;
if (!q.TryGetValue("ids", out var idsRaw))
    return false;
~~~

Home Screen Sections does not use `ids` for these calls, so those requests were treated like normal listings and got over-filtered, which resulted in slow loading and timeouts.

I changed the guard to `ctx.IsApiListing()` and added `isSingleItemQuery = filter.ItemIds is { Length: 1 }`. Filters now apply only when `ctx.IsApiListing() && !isSingleItemQuery`.

This keeps listing filters on real listing endpoints and fixes Home Screen Sections latest rows loading correctly.
