### PR TITLE
feat: improve search routing and import controls

### DIFF
--- a/Config/PluginConfiguration.cs
+++ b/Config/PluginConfiguration.cs
@@ -25,6 +25,10 @@ public class PluginConfiguration : BasePluginConfiguration
     public bool CreateCollections { get; set; } = false;
     public int MaxCollectionItems { get; set; } = 100;
     public bool DisableSearch { get; set; } = false;
+    public bool SplitCatalogImportsByGenre { get; set; } = true;
+    public string AdultMoviePath { get; set; } = "";
+    public string AdultSeriesPath { get; set; } = "";
+    public bool DisableRemoteImages { get; set; } = false;
 
     public List<CatalogConfig> Catalogs { get; set; } = [];
     public List<UserConfig> UserConfigs { get; set; } = [];
@@ -81,6 +85,10 @@ public class UserConfig
             MoviePath = MoviePath,
             SeriesPath = SeriesPath,
             DisableSearch = DisableSearch,
+            SplitCatalogImportsByGenre = baseConfig.SplitCatalogImportsByGenre,
+            AdultMoviePath = baseConfig.AdultMoviePath,
+            AdultSeriesPath = baseConfig.AdultSeriesPath,
+            DisableRemoteImages = baseConfig.DisableRemoteImages,
 
             // All other fields from base config
             StreamTTL = baseConfig.StreamTTL,

--- a/Config/config.html
+++ b/Config/config.html
@@ -55,6 +55,34 @@
               <input is="emby-input" type="text" id="txtSeriesPath" class="emby-input" />
               <div class="fieldDescription">Filesystem path for series items. Use this path as library folder.</div>
             </div>
+
+            <h3 class="sectionTitle" style="margin-top: 2em;">Import Routing</h3>
+
+            <div class="checkboxContainer checkboxContainer-withDescription" style="margin-bottom: 0.5em;">
+              <label>
+                <input is="emby-checkbox" type="checkbox" id="chkSplitCatalogImportsByGenre" />
+                <span>Split catalog imports into genre folders</span>
+              </label>
+            </div>
+
+            <div class="inputContainer">
+              <label class="inputLabel inputLabelUnfocused" for="txtAdultMoviePath">Adult movies path (optional):</label>
+              <input is="emby-input" type="text" id="txtAdultMoviePath" class="emby-input" />
+              <div class="fieldDescription">Leave empty to use normal movies path.</div>
+            </div>
+
+            <div class="inputContainer">
+              <label class="inputLabel inputLabelUnfocused" for="txtAdultSeriesPath">Adult series path (optional):</label>
+              <input is="emby-input" type="text" id="txtAdultSeriesPath" class="emby-input" />
+              <div class="fieldDescription">Leave empty to use normal series path.</div>
+            </div>
+
+            <div class="checkboxContainer checkboxContainer-withDescription" style="margin-bottom: 0.5em;">
+              <label>
+                <input is="emby-checkbox" type="checkbox" id="chkDisableRemoteImages" />
+                <span>Disable remote images (temporary)</span>
+              </label>
+            </div>
        
 
             <h3 class="sectionTitle" style="margin-top: 2em;">Search & Discovery</h3>
@@ -119,7 +147,11 @@
                   <!-- Catalogs rendered here -->
                 </div>
 
-                <div style="margin-top: 1.5em; display: flex; justify-content: flex-end;">
+                <div style="margin-top: 1.5em; display: flex; justify-content: flex-end; gap: 0.75em;">
+                  <button type="button" is="emby-button" class="raised emby-button" id="btnImportEverything"
+                    style="background: #c0392b; color: #fff;">
+                    <span>Import Everything (No Filter)</span>
+                  </button>
                   <button type="button" is="emby-button" class="raised emby-button" id="btnImportAll"
                     style="background: #00a4dc; color: #fff;">
                     <span>Import</span>
@@ -254,6 +286,10 @@
         const txtUrl = page.querySelector('#txtUrl');
         const txtMoviePath = page.querySelector('#txtMoviePath');
         const txtSeriesPath = page.querySelector('#txtSeriesPath');
+        const chkSplitCatalogImportsByGenre = page.querySelector('#chkSplitCatalogImportsByGenre');
+        const txtAdultMoviePath = page.querySelector('#txtAdultMoviePath');
+        const txtAdultSeriesPath = page.querySelector('#txtAdultSeriesPath');
+        const chkDisableRemoteImages = page.querySelector('#chkDisableRemoteImages');
 
         const txtStreamTTL = page.querySelector('#txtStreamTTL');
         const chkEnableMixed = page.querySelector('#chkEnableMixed');
@@ -522,6 +558,21 @@
           }
         }
 
+        async function triggerImportEverything() {
+          if (!confirm('Start unfiltered import for all catalogs? This can import a very large amount of items.')) return;
+          Dashboard.showLoadingMsg();
+          try {
+            const url = window.ApiClient.getUrl('gelato/catalogs/import-all-unfiltered');
+            await window.ApiClient.ajax({ type: "POST", url: url });
+            Dashboard.alert("Unfiltered global import started in background.");
+          } catch (e) {
+            console.error(e);
+            Dashboard.alert("Error starting unfiltered global import.");
+          } finally {
+            Dashboard.hideLoadingMsg();
+          }
+        }
+
         async function loadConfig() {
           Dashboard.showLoadingMsg();
           try {
@@ -532,6 +583,10 @@
             if (txtUrl) txtUrl.value = cfg.Url || "";
             if (txtMoviePath) txtMoviePath.value = cfg.MoviePath || "";
             if (txtSeriesPath) txtSeriesPath.value = cfg.SeriesPath || "";
+            if (chkSplitCatalogImportsByGenre) chkSplitCatalogImportsByGenre.checked = cfg.SplitCatalogImportsByGenre ?? true;
+            if (txtAdultMoviePath) txtAdultMoviePath.value = cfg.AdultMoviePath || "";
+            if (txtAdultSeriesPath) txtAdultSeriesPath.value = cfg.AdultSeriesPath || "";
+            if (chkDisableRemoteImages) chkDisableRemoteImages.checked = cfg.DisableRemoteImages || false;
             if (txtStreamTTL) txtStreamTTL.value = cfg.StreamTTL || 3600;
             if (chkEnableMixed) chkEnableMixed.checked = cfg.EnableMixed ?? true;
             if (chkDisableSearch) chkDisableSearch.checked = cfg.DisableSearch || false;
@@ -559,6 +614,10 @@
             cfg.Url = txtUrl.value.trim();
             cfg.MoviePath = txtMoviePath.value.trim();
             cfg.SeriesPath = txtSeriesPath.value.trim();
+            cfg.SplitCatalogImportsByGenre = chkSplitCatalogImportsByGenre.checked;
+            cfg.AdultMoviePath = txtAdultMoviePath.value.trim();
+            cfg.AdultSeriesPath = txtAdultSeriesPath.value.trim();
+            cfg.DisableRemoteImages = chkDisableRemoteImages.checked;
 
             
             // Stream TTL
@@ -734,6 +793,7 @@
           txtCatalogSearch.addEventListener('input', renderCatalogs);
           btnRefreshCatalogs.addEventListener('click', loadCatalogs);
           page.querySelector('#btnImportAll').addEventListener('click', triggerImportAll);
+          page.querySelector('#btnImportEverything').addEventListener('click', triggerImportEverything);
           selUserConfig.addEventListener('change', onUserSelected);
 
           // Tab 1 active by default

--- a/Controllers/CatalogController.cs
+++ b/Controllers/CatalogController.cs
@@ -98,4 +98,24 @@ public class CatalogController(
 
         return Accepted();
     }
+
+    [HttpPost("import-all-unfiltered")]
+    public ActionResult ImportAllUnfiltered()
+    {
+        logger.LogInformation("Manual unfiltered import triggered for all catalogs");
+
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                await importService.SyncAllUnfilteredAsync(CancellationToken.None);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error in manual unfiltered import for all catalogs");
+            }
+        });
+
+        return Accepted();
+    }
 }

--- a/Filters/SearchActionFilter.cs
+++ b/Filters/SearchActionFilter.cs
@@ -35,10 +35,24 @@ public class SearchActionFilter(
             return;
         }
 
-        // Strip "local:" prefix if present and pass through to default handler
+        // local search is default; keep old local: prefix for compatibility
         if (searchTerm.StartsWith("local:", StringComparison.OrdinalIgnoreCase))
         {
             ctx.ActionArguments["searchTerm"] = searchTerm[6..].Trim();
+            await next();
+            return;
+        }
+
+        // only intercept explicit stremio: searches
+        if (!searchTerm.StartsWith("stremio:", StringComparison.OrdinalIgnoreCase))
+        {
+            await next();
+            return;
+        }
+
+        searchTerm = searchTerm[8..].Trim();
+        if (string.IsNullOrWhiteSpace(searchTerm))
+        {
             await next();
             return;
         }

--- a/Gelato.csproj
+++ b/Gelato.csproj
@@ -4,7 +4,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <AssemblyName>Gelato</AssemblyName>
-    <Version>0.26.0.0</Version>
+    <Version>7.0.0.2</Version>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>

--- a/GelatoManager.cs
+++ b/GelatoManager.cs
@@ -124,6 +124,38 @@ public sealed class GelatoManager(
         return TryGetFolder(cfg.SeriesPath);
     }
 
+    public Folder? TryGetFolderByPath(string path)
+    {
+        return TryGetFolder(path);
+    }
+
+    public Folder? GetOrCreateSubFolder(Folder parent, string path, string name, CancellationToken ct)
+    {
+        var existing = TryGetFolder(path);
+        if (existing is not null)
+            return existing;
+
+        if (string.IsNullOrWhiteSpace(path))
+            return null;
+
+        SeedFolder(path);
+
+        var folder = new Folder
+        {
+            Name = name,
+            Path = path,
+            Id = libraryManager.GetNewItemId(path, typeof(Folder)),
+            DateCreated = DateTime.UtcNow,
+            DateModified = DateTime.UtcNow,
+            DateLastSaved = DateTime.UtcNow,
+            DateLastRefreshed = DateTime.UtcNow,
+        };
+
+        parent.AddChild(folder);
+        repo.SaveItems([folder], ct);
+        return folder;
+    }
+
     private Folder? TryGetFolder(string path)
     {
         if (string.IsNullOrWhiteSpace(path))
@@ -771,7 +803,7 @@ public sealed class GelatoManager(
                 };
 
                 var primary = seriesMeta.App_Extras?.SeasonPosters?[seasonIndex];
-                if (!string.IsNullOrWhiteSpace(primary))
+                if (!cfg.DisableRemoteImages && !string.IsNullOrWhiteSpace(primary))
                 {
                     season.ImageInfos = new List<ItemImageInfo>
                     {
@@ -1043,8 +1075,9 @@ public sealed class GelatoManager(
         item.DateLastSaved = DateTime.UtcNow;
         item.DateCreated = DateTime.UtcNow;
 
+        var disableRemoteImages = GelatoPlugin.Instance?.Configuration.DisableRemoteImages ?? false;
         var primary = meta.Poster ?? meta.Thumbnail;
-        if (!string.IsNullOrWhiteSpace(primary))
+        if (!disableRemoteImages && !string.IsNullOrWhiteSpace(primary))
         {
             item.ImageInfos = new List<ItemImageInfo>
             {

--- a/GelatoStremioProvider.cs
+++ b/GelatoStremioProvider.cs
@@ -14,8 +14,19 @@ public class GelatoStremioProvider(
 )
 {
     private StremioManifest? _manifest;
-    private StremioCatalog? _movieSearchCatalog;
-    private StremioCatalog? _seriesSearchCatalog;
+    private List<StremioCatalog> _movieSearchCatalogs = [];
+    private List<StremioCatalog> _seriesSearchCatalogs = [];
+    private static readonly string[] AdultCatalogKeywords =
+    [
+        "porn",
+        "xxx",
+        "adult",
+        "hentai",
+        "nsfw",
+        "erotic",
+        "sex",
+        "18+",
+    ];
     private static readonly JsonSerializerOptions JsonOpts = new()
     {
         PropertyNameCaseInsensitive = true,
@@ -80,6 +91,22 @@ public class GelatoStremioProvider(
         }
     }
 
+    private static bool IsProbablyAdultCatalog(StremioCatalog catalog)
+    {
+        var text = $"{catalog.Id} {catalog.Name}";
+        return AdultCatalogKeywords.Any(k =>
+            text.Contains(k, StringComparison.OrdinalIgnoreCase)
+        );
+    }
+
+    private static List<StremioCatalog> RankSearchCatalogs(IEnumerable<StremioCatalog> catalogs)
+    {
+        return catalogs
+            .OrderBy(IsProbablyAdultCatalog)
+            .ThenBy(c => c.Id.Contains("people", StringComparison.OrdinalIgnoreCase))
+            .ToList();
+    }
+
     public async Task<StremioManifest?> GetManifestAsync(bool force = false)
     {
         if (!force && _manifest is not null)
@@ -92,45 +119,49 @@ public class GelatoStremioProvider(
 
             if (m?.Catalogs != null)
             {
-                _movieSearchCatalog = m
-                    .Catalogs.Where(c =>
+                _movieSearchCatalogs = RankSearchCatalogs(
+                    m.Catalogs.Where(c =>
                         string.Equals(
                             c.Type,
                             nameof(StremioMediaType.Movie),
                             StringComparison.CurrentCultureIgnoreCase
                         ) && c.IsSearchCapable()
                     )
-                    .OrderBy(c => c.Id.Contains("people", StringComparison.OrdinalIgnoreCase))
-                    .FirstOrDefault();
+                );
 
-                _seriesSearchCatalog = m
-                    .Catalogs.Where(c =>
+                _seriesSearchCatalogs = RankSearchCatalogs(
+                    m.Catalogs.Where(c =>
                         string.Equals(
                             c.Type,
                             nameof(StremioMediaType.Series),
                             StringComparison.CurrentCultureIgnoreCase
                         ) && c.IsSearchCapable()
                     )
-                    .OrderBy(c => c.Id.Contains("people", StringComparison.OrdinalIgnoreCase))
-                    .FirstOrDefault();
+                );
             }
 
-            if (_movieSearchCatalog == null)
+            if (_movieSearchCatalogs.Count == 0)
             {
                 log.LogWarning("manifest has no search-capable movie catalog");
             }
             else
             {
-                log.LogDebug("manifest uses movie search catalog: {Id}", _movieSearchCatalog.Id);
+                log.LogDebug(
+                    "manifest movie search catalogs: {Ids}",
+                    string.Join(",", _movieSearchCatalogs.Select(c => c.Id))
+                );
             }
 
-            if (_seriesSearchCatalog == null)
+            if (_seriesSearchCatalogs.Count == 0)
             {
                 log.LogWarning("manifest has no search-capable series catalog");
             }
             else
             {
-                log.LogDebug("manifest uses series search catalog: {Id}", _seriesSearchCatalog.Id);
+                log.LogDebug(
+                    "manifest series search catalogs: {Ids}",
+                    string.Join(",", _seriesSearchCatalogs.Select(c => c.Id))
+                );
             }
             return m;
         }
@@ -231,14 +262,14 @@ public class GelatoStremioProvider(
         if (manifest == null)
             return [];
 
-        var catalog = mediaType switch
+        var catalogs = mediaType switch
         {
-            StremioMediaType.Movie => _movieSearchCatalog,
-            StremioMediaType.Series => _seriesSearchCatalog,
-            _ => null,
+            StremioMediaType.Movie => _movieSearchCatalogs,
+            StremioMediaType.Series => _seriesSearchCatalogs,
+            _ => [],
         };
 
-        if (catalog == null)
+        if (catalogs.Count == 0)
         {
             log.LogError(
                 "SearchAsync: {mediaType} has no search catalog, please enable one in aiostreams.",
@@ -247,7 +278,45 @@ public class GelatoStremioProvider(
             return [];
         }
 
-        return await GetCatalogMetasAsync(catalog.Id, mediaType.ToString(), query, skip);
+        var merged = new List<StremioMeta>();
+
+        foreach (var catalog in catalogs)
+        {
+            try
+            {
+                var metas = await GetCatalogMetasAsync(catalog.Id, mediaType.ToString(), query, skip);
+                merged.AddRange(metas);
+            }
+            catch (Exception ex)
+            {
+                log.LogWarning(
+                    ex,
+                    "SearchAsync: failed querying {MediaType} catalog {CatalogId}",
+                    mediaType,
+                    catalog.Id
+                );
+            }
+        }
+
+        if (merged.Count == 0)
+            return [];
+
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var deduped = new List<StremioMeta>(merged.Count);
+
+        foreach (var meta in merged)
+        {
+            var key = string.IsNullOrWhiteSpace(meta.Id)
+                ? $"{meta.GetName()}|{meta.GetYear()}|{meta.Type}"
+                : $"{meta.Id}|{meta.Type}";
+
+            if (!seen.Add(key))
+                continue;
+
+            deduped.Add(meta);
+        }
+
+        return deduped;
     }
 }
 

--- a/Services/CatalogImportService.cs
+++ b/Services/CatalogImportService.cs
@@ -20,11 +20,25 @@ public class CatalogImportService(
     ILibraryManager libraryManager
 )
 {
+    private static readonly string[] AdultKeywords =
+    [
+        "adult",
+        "porn",
+        "xxx",
+        "hentai",
+        "erotic",
+        "nsfw",
+        "18+",
+        "sex",
+    ];
+
     public async Task ImportCatalogAsync(
         string catalogId,
         string type,
         CancellationToken ct,
-        IProgress<double>? progress = null
+        IProgress<double>? progress = null,
+        bool ignoreEnabled = false,
+        bool importAllItems = false
     )
     {
         var catalogCfg = catalogService.GetCatalogConfig(catalogId, type);
@@ -34,7 +48,7 @@ public class CatalogImportService(
             return;
         }
 
-        if (!catalogCfg.Enabled)
+        if (!ignoreEnabled && !catalogCfg.Enabled)
         {
             logger.LogInformation("Catalog {Id} {Type} is disabled, skipping.", catalogId, type);
             return;
@@ -54,15 +68,16 @@ public class CatalogImportService(
             logger.LogWarning("No movie root folder found");
         }
 
-        var maxItems = catalogCfg.MaxItems;
+        var maxItems = importAllItems ? int.MaxValue : catalogCfg.MaxItems;
         long done = 0;
 
         var stopwatch = Stopwatch.StartNew();
         logger.LogInformation(
-            "Starting import for catalog {Name} ({Id}) - Limit: {Limit}",
+            "Starting import for catalog {Name} ({Id}) - Limit: {Limit} - ImportAllItems: {ImportAllItems}",
             catalogCfg.Name,
             catalogId,
-            maxItems
+            maxItems,
+            importAllItems
         );
 
         try
@@ -71,7 +86,7 @@ public class CatalogImportService(
             var processedItems = 0;
             var importedIds = new ConcurrentBag<Guid>();
 
-            while (processedItems < maxItems)
+            while (importAllItems || processedItems < maxItems)
             {
                 ct.ThrowIfCancellationRequested();
 
@@ -87,7 +102,7 @@ public class CatalogImportService(
                 foreach (var meta in page)
                 {
                     ct.ThrowIfCancellationRequested();
-                    if (processedItems >= maxItems)
+                    if (!importAllItems && processedItems >= maxItems)
                     {
                         break;
                     }
@@ -97,12 +112,15 @@ public class CatalogImportService(
 
                     // catalog can contain multiple types.
 
-                    var root = baseItemKind switch
-                    {
-                        BaseItemKind.Series => seriesFolder,
-                        BaseItemKind.Movie => movieFolder,
-                        _ => null,
-                    };
+                    var root = ResolveImportRoot(
+                        cfg,
+                        catalogCfg,
+                        meta,
+                        baseItemKind,
+                        movieFolder,
+                        seriesFolder,
+                        ct
+                    );
 
                     if (root is not null)
                     {
@@ -136,7 +154,8 @@ public class CatalogImportService(
                     }
 
                     processedItems++;
-                    progress?.Report(processedItems * 100.0 / maxItems);
+                    if (!importAllItems && maxItems > 0)
+                        progress?.Report(processedItems * 100.0 / maxItems);
                 }
 
                 skip += page.Count;
@@ -178,6 +197,85 @@ public class CatalogImportService(
             stopwatch.Elapsed.Seconds,
             stopwatch.Elapsed.TotalSeconds
         );
+    }
+
+    private Folder? ResolveImportRoot(
+        PluginConfiguration cfg,
+        CatalogConfig catalogCfg,
+        StremioMeta meta,
+        BaseItemKind kind,
+        Folder? defaultMovieRoot,
+        Folder? defaultSeriesRoot,
+        CancellationToken ct
+    )
+    {
+        var isAdult = IsAdult(meta, catalogCfg);
+
+        var path = kind switch
+        {
+            BaseItemKind.Movie when isAdult && !string.IsNullOrWhiteSpace(cfg.AdultMoviePath) =>
+                cfg.AdultMoviePath,
+            BaseItemKind.Series when isAdult && !string.IsNullOrWhiteSpace(cfg.AdultSeriesPath) =>
+                cfg.AdultSeriesPath,
+            BaseItemKind.Movie => cfg.MoviePath,
+            BaseItemKind.Series => cfg.SeriesPath,
+            _ => string.Empty,
+        };
+
+        if (string.IsNullOrWhiteSpace(path))
+            return null;
+
+        var baseRoot = kind switch
+        {
+            BaseItemKind.Movie when path == cfg.MoviePath => defaultMovieRoot,
+            BaseItemKind.Series when path == cfg.SeriesPath => defaultSeriesRoot,
+            _ => manager.TryGetFolderByPath(path),
+        };
+
+        if (baseRoot is null)
+        {
+            logger.LogWarning(
+                "No root folder found for {Kind} path {Path}. Add this path to Jellyfin library and scan once.",
+                kind,
+                path
+            );
+            return null;
+        }
+
+        var bucket = isAdult ? "Adult" : GetPrimaryGenre(meta);
+        if (!cfg.SplitCatalogImportsByGenre)
+            return baseRoot;
+
+        var genrePath = Path.Combine(path, SanitizeSegment(bucket));
+        var genreFolder = manager.GetOrCreateSubFolder(baseRoot, genrePath, bucket, ct);
+        return genreFolder ?? baseRoot;
+    }
+
+    private static string GetPrimaryGenre(StremioMeta meta)
+    {
+        var genres = meta.Genres ?? meta.Genre;
+        if (genres is null || genres.Count == 0)
+            return "Unknown";
+
+        var first = genres.FirstOrDefault(g => !string.IsNullOrWhiteSpace(g));
+        return string.IsNullOrWhiteSpace(first) ? "Unknown" : first.Trim();
+    }
+
+    private static bool IsAdult(StremioMeta meta, CatalogConfig catalogCfg)
+    {
+        var genres = meta.Genres ?? meta.Genre ?? [];
+        var joinedGenres = string.Join(' ', genres);
+        var text = $"{meta.GetName()} {meta.Description} {meta.Overview} {catalogCfg.Name} {catalogCfg.Id} {joinedGenres}";
+
+        return AdultKeywords.Any(k => text.Contains(k, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static string SanitizeSegment(string value)
+    {
+        var invalid = Path.GetInvalidFileNameChars();
+        var chars = value.Select(c => invalid.Contains(c) ? '_' : c).ToArray();
+        var s = new string(chars).Trim();
+        return string.IsNullOrWhiteSpace(s) ? "Unknown" : s;
     }
 
     private async Task<BoxSet?> GetOrCreateBoxSetAsync(CatalogConfig config)
@@ -289,5 +387,30 @@ public class CatalogImportService(
         libraryManager.QueueLibraryScan();
 
         progress?.Report(100);
+    }
+
+    public async Task SyncAllUnfilteredAsync(CancellationToken ct)
+    {
+        var catalogs = await catalogService.GetCatalogsAsync(Guid.Empty);
+
+        if (catalogs.Count == 0)
+            return;
+
+        foreach (var cat in catalogs)
+        {
+            ct.ThrowIfCancellationRequested();
+            logger.LogInformation("Processing unfiltered catalog import: {Name}", cat.Name);
+            await ImportCatalogAsync(
+                    cat.Id,
+                    cat.Type,
+                    ct,
+                    progress: null,
+                    ignoreEnabled: true,
+                    importAllItems: true
+                )
+                .ConfigureAwait(false);
+        }
+
+        libraryManager.QueueLibraryScan();
     }
 }

--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 ---
 name: "Gelato"
 guid: "94EA4E14-8163-4989-96FE-0A2094BC2D6A"
-version: "0.26.6.5"
+version: "7.0.0.2"
 targetAbi: "10.11.6.0"
 framework: "net9.0"
 owner: "lstb1t"


### PR DESCRIPTION
## Summary
- keep Jellyfin search local by default and require `stremio:` prefix for remote catalog lookup, while preserving `local:` compatibility
- query all search-capable movie/series catalogs (non-adult first), merge results, and de-duplicate to avoid adult-catalog hijacking
- add unfiltered import controls, configurable genre/adult folder routing, and a temporary remote-image disable switch to stabilize large imports
- bump plugin version to `7.0.0.2` to ensure Jellyfin loads updated config UI and behavior

## Verification
- `dotnet build Gelato.sln -c Release`