### PR TITLE
feat: emit .strm files for stub items (opt-in via EmitStrmFiles config flag)

### DIFF
--- a/Config/PluginConfiguration.cs
+++ b/Config/PluginConfiguration.cs
@@ -28,6 +28,7 @@ public class PluginConfiguration : BasePluginConfiguration
     public bool DisableSearch { get; set; } = false;
     public bool EnableJavaScriptInjection { get; set; } = false;
     public bool LazyImages { get; set; } = false;
+    public bool EmitStrmFiles { get; set; } = false;
     public List<CatalogConfig> Catalogs { get; set; } = [];
     public List<UserConfig> UserConfigs { get; set; } = [];
 
@@ -99,6 +100,7 @@ public class UserConfig
             FFmpegProbeSize = baseConfig.FFmpegProbeSize,
             CreateCollections = baseConfig.CreateCollections,
             MaxCollectionItems = baseConfig.MaxCollectionItems,
+            EmitStrmFiles = baseConfig.EmitStrmFiles,
             UserConfigs = baseConfig.UserConfigs,
         };
     }

--- a/Config/config.html
+++ b/Config/config.html
@@ -77,6 +77,14 @@
               <div class="fieldDescription">Download images on first access instead of at import time. Recommended.</div>
             </div>
 
+            <div class="checkboxContainer checkboxContainer-withDescription">
+              <label>
+                <input is="emby-checkbox" type="checkbox" id="chkEmitStrmFiles" />
+                <span>Emit .strm files</span>
+              </label>
+              <div class="fieldDescription">Write .strm files for stub items so they have real filesystem paths. Enables BoxSet persistence across restarts. Requires catalog reimport after enabling.</div>
+            </div>
+
 
             <div class="checkboxContainer checkboxContainer-withDescription">
               <label>
@@ -299,6 +307,7 @@
         const txtFFmpegProbeSize = page.querySelector('#txtFFmpegProbeSize');
         const chkEnableJavaScriptInjection = page.querySelector('#chkEnableJavaScriptInjection');
         const chkLazyImages = page.querySelector('#chkLazyImages');
+        const chkEmitStrmFiles = page.querySelector('#chkEmitStrmFiles');
 
         // Catalogs
         const catalogsList = page.querySelector('#catalogsList');
@@ -579,6 +588,7 @@
             if (txtFFmpegProbeSize) txtFFmpegProbeSize.value = cfg.FFmpegProbeSize || "25M";
             if (chkEnableJavaScriptInjection) chkEnableJavaScriptInjection.checked = cfg.EnableJavaScriptInjection || false;
             if (chkLazyImages) chkLazyImages.checked = cfg.LazyImages ?? true;
+            if (chkEmitStrmFiles) chkEmitStrmFiles.checked = cfg.EmitStrmFiles || false;
 
             // User Overrides Logic
             await loadUsers();
@@ -614,6 +624,7 @@
             cfg.FFmpegProbeSize = txtFFmpegProbeSize.value;
             cfg.EnableJavaScriptInjection = chkEnableJavaScriptInjection.checked;
             cfg.LazyImages = chkLazyImages.checked;
+            cfg.EmitStrmFiles = chkEmitStrmFiles.checked;
 
             // Only collect catalog states if catalogs have been loaded (i.e., if we're on catalogs tab or it was loaded)
             if (allCatalogs.length > 0) {

--- a/Decorators/CollectionManagerDecorator.cs
+++ b/Decorators/CollectionManagerDecorator.cs
@@ -74,6 +74,11 @@ public sealed class CollectionManagerDecorator(
                 {
                     LibraryItemId = item.Id.ToString("N", CultureInfo.InvariantCulture),
                     Type = LinkedChildType.Manual,
+                    // set Path so CleanCollectionsAndPlaylists keeps the entry (it strips items that fail File.Exists)
+                    Path = !string.IsNullOrEmpty(item.Path)
+                        && !item.Path.StartsWith("gelato://", StringComparison.OrdinalIgnoreCase)
+                        ? item.Path
+                        : null,
                 }
                 : LinkedChild.Create(item);
 

--- a/Decorators/MediaSourceManagerDecorator.cs
+++ b/Decorators/MediaSourceManagerDecorator.cs
@@ -254,9 +254,14 @@ public sealed class MediaSourceManagerDecorator(
 
         sources.AddRange(gelatoSources);
 
-        if (sources.Count > 1)
+        if (video.IsGelato())
         {
-            // remove primary from list when there are streams
+            // primary source is either a gelato:// stub or a .strm shortcut, neither is playable
+            sources = gelatoSources;
+        }
+        else if (sources.Count > 1)
+        {
+
             sources = sources
                 .Where(k =>
                     !(k.Path?.StartsWith("gelato", StringComparison.OrdinalIgnoreCase) ?? false)

--- a/GelatoManager.cs
+++ b/GelatoManager.cs
@@ -42,6 +42,30 @@ public sealed class GelatoManager(
         return networkConfig.InternalHttpPort;
     }
 
+    private static readonly HashSet<char> _invalidPathChars = new(Path.GetInvalidFileNameChars());
+
+    private static string SanitizePathSegment(string name) =>
+        new string(name.Select(c => _invalidPathChars.Contains(c) ? '_' : c).ToArray()).Trim(' ', '.');
+
+    private void TryEmitStrm(BaseItem item, string strmPath, string stremioType, string id)
+    {
+        try
+        {
+            if (!File.Exists(strmPath))
+            {
+                Directory.CreateDirectory(Path.GetDirectoryName(strmPath)!);
+                File.WriteAllText(strmPath, $"http://127.0.0.1:{GetHttpPort()}/gelato/meta/{stremioType}/{id}");
+            }
+            item.Path = strmPath;
+            _log.LogDebug("Emitted .strm for {Id} at {StrmPath}", id, strmPath);
+        }
+        catch (Exception ex)
+        {
+            _log.LogWarning(ex, "Failed to emit .strm for {Id}, falling back to gelato:// path", id);
+            item.Path = $"gelato://stub/{id}";
+        }
+    }
+
     public void SetStremioSubtitlesCache(Guid guid, List<StremioSubtitle> subs)
     {
         memoryCache.Set($"subs:{guid}", subs, TimeSpan.FromMinutes(3600));
@@ -136,7 +160,7 @@ public sealed class GelatoManager(
         }
 
         SeedFolder(path);
-        return repo.GetItemList(new InternalItemsQuery { IsDeadPerson = true, Path = path })
+        return repo.GetItemList(new InternalItemsQuery { Path = path })
             .OfType<Folder>()
             .FirstOrDefault();
     }
@@ -217,13 +241,25 @@ public sealed class GelatoManager(
 
             if (existing is not null)
             {
-                _log.LogDebug(
-                    "found existing {Kind}: {Id} for {Name}",
-                    existing.GetBaseItemKind(),
-                    existing.Id,
-                    existing.Name
-                );
-                return (existing, false);
+                if (cfg.EmitStrmFiles && existing.Path.StartsWith("gelato://stub/", StringComparison.OrdinalIgnoreCase))
+                {
+                    _log.LogInformation(
+                        "InsertMeta: migrating {Kind} {Id} ({Name}) from gelato:// to .strm, deleting old record",
+                        existing.GetBaseItemKind(), existing.Id, existing.Name
+                    );
+                    libraryManager.DeleteItem(existing, new DeleteOptions { DeleteFileLocation = false }, true);
+                    existing = null;
+                }
+                else
+                {
+                    _log.LogDebug(
+                        "found existing {Kind}: {Id} for {Name}",
+                        existing.GetBaseItemKind(),
+                        existing.Id,
+                        existing.Name
+                    );
+                    return (existing, false);
+                }
             }
 
             var lookupId = meta.ImdbId ?? meta.Id;
@@ -262,13 +298,24 @@ public sealed class GelatoManager(
 
         if (existing is not null)
         {
-            _log.LogDebug(
-                "found existing {Kind}: {Id} for {Name}",
-                existing.GetBaseItemKind(),
-                existing.Id,
-                existing.Name
-            );
-            return (existing, false);
+            if (cfg.EmitStrmFiles && existing.Path.StartsWith("gelato://stub/", StringComparison.OrdinalIgnoreCase))
+            {
+                _log.LogInformation(
+                    "InsertMeta: migrating {Kind} {Id} ({Name}) from gelato:// to .strm, deleting old record",
+                    existing.GetBaseItemKind(), existing.Id, existing.Name
+                );
+                libraryManager.DeleteItem(existing, new DeleteOptions { DeleteFileLocation = false }, true);
+            }
+            else
+            {
+                _log.LogDebug(
+                    "found existing {Kind}: {Id} for {Name}",
+                    existing.GetBaseItemKind(),
+                    existing.Id,
+                    existing.Name
+                );
+                return (existing, false);
+            }
         }
 
         await EnrichMetaAsync(meta, ct).ConfigureAwait(false);
@@ -776,7 +823,12 @@ public sealed class GelatoManager(
             ct.ThrowIfCancellationRequested();
 
             var seasonIndex = seasonGroup.Key;
-            var seasonPath = $"{series.Path}:{seasonIndex}";
+            var useStrmForSeason = cfg.EmitStrmFiles
+                && !string.IsNullOrWhiteSpace(series.Path)
+                && !series.Path.StartsWith("gelato://", StringComparison.OrdinalIgnoreCase);
+            var seasonPath = useStrmForSeason
+                ? Path.Combine(series.Path, $"Season {seasonIndex:D2}")
+                : $"{series.Path}:{seasonIndex}";
 
             if (!existingSeasonsDict.TryGetValue(seasonIndex, out var season))
             {
@@ -888,6 +940,17 @@ public sealed class GelatoManager(
                 episode.ParentId = season.Id;
                 episode.SeriesPresentationUniqueKey = season.SeriesPresentationUniqueKey;
                 episode.PresentationUniqueKey = episode.GetPresentationUniqueKey();
+
+                if (useStrmForSeason)
+                {
+                    var safeEpName = SanitizePathSegment(
+                        $"{episode.Name} S{seasonIndex:D2}E{index.Value:D2}"
+                    );
+                    var strmPath = Path.Combine(seasonPath, safeEpName + ".strm");
+                    TryEmitStrm(episode, strmPath, "series", epMeta.Id ?? "");
+                    episode.Id = libraryManager.GetNewItemId(episode.Path, episode.GetType());
+                    episode.PresentationUniqueKey = episode.CreatePresentationUniqueKey();
+                }
 
                 allNewEpisodes.Add(episode);
                 episodesInserted++;
@@ -1402,7 +1465,42 @@ public sealed class GelatoManager(
         }
 
         item.ProductionYear = meta.GetYear();
-        item.Path = $"gelato://stub/{id}";
+
+        var cfg = GelatoPlugin.Instance?.Configuration;
+        if (cfg?.EmitStrmFiles == true && meta.Type != StremioMediaType.Episode)
+        {
+            var safeName = SanitizePathSegment(
+                $"{item.Name} ({item.ProductionYear}) [imdbid-{id}]"
+            );
+            if (meta.Type == StremioMediaType.Movie)
+            {
+                var strmPath = Path.Combine(cfg.MoviePath, safeName, safeName + ".strm");
+                TryEmitStrm(item, strmPath, "movie", id);
+            }
+            else if (meta.Type == StremioMediaType.Series)
+            {
+                // series path is a directory; episodes are written in SyncSeriesTreesAsync
+                var seriesDir = Path.Combine(cfg.SeriesPath, safeName);
+                try
+                {
+                    Directory.CreateDirectory(seriesDir);
+                    item.Path = seriesDir;
+                }
+                catch (Exception ex)
+                {
+                    _log.LogWarning(ex, "Failed to create series dir for {Id}, falling back to gelato:// path", id);
+                    item.Path = $"gelato://stub/{id}";
+                }
+            }
+            else
+            {
+                item.Path = $"gelato://stub/{id}";
+            }
+        }
+        else
+        {
+            item.Path = $"gelato://stub/{id}";
+        }
 
         // Provider IDs — skip for episodes since the parent series IMDB id is used there
         if (meta.Type is not StremioMediaType.Episode && !string.IsNullOrWhiteSpace(id))


### PR DESCRIPTION
## Problem

Gelato stub items use `gelato://stub/{id}` as their `Path`. These items can't persist in Jellyfin BoxSets across restarts because the built-in `CleanCollectionsAndPlaylists` task strips `LinkedChild` entries whose paths don't resolve to real filesystem locations. PR jellyfin/jellyfin#16062 (targeting 10.12) will make this structurally impossible via FK constraints.

## Solution

Add an opt-in config flag `EmitStrmFiles` (default `false`). When enabled:

- Movies: a `.strm` file is written to `{MoviePath}/{Name} ({Year}) [imdbid-{id}]/` and the item's `Path` is set to that file
- Series: directory tree is created at `{SeriesPath}/{Name} ({Year}) [imdbid-{id}]/Season {n}/`; episode `.strm` files are written inside the season directories
- `.strm` content is the existing `GET /gelato/meta/{type}/{id}` endpoint (returns JSON metadata, not used for playback since `MediaSourceManagerDecorator` always intercepts stream resolution)
- Existing `gelato://` items are unaffected until purged and reimported

This gives every stub item a real filesystem path so BoxSet membership survives restarts without any Jellyfin core changes.

## Changes

- `Config/PluginConfiguration.cs` - add `EmitStrmFiles` bool property
- `Config/config.html` - add checkbox in General tab
- `GelatoManager.cs` - `.strm` emission in `IntoBaseItem()` (movies/episodes) and `SyncSeriesTreesAsync()` (series/season directory structure)
- `Decorators/MediaSourceManagerDecorator.cs` - filter out the `.strm` shortcut path from primary sources so Gelato streams are always used for playback

## Behaviour notes

- Enabling the flag only affects new imports. Existing `gelato://` items must be purged and reimported.
- Purge via the existing `DeleteOptions { DeleteFileLocation = true }` path cleans up `.strm` files and empty parent directories correctly.
- `SanitizeFileName` strips characters invalid on Windows/Linux filesystems.
- Falls back to `gelato://stub/{id}` path if directory creation or file write fails (logged as warning).

## Testing

Tested on Jellyfin 10.11.8 (LXC, net9.0):

- `.strm` files written at correct paths with correct content
- Item `Path` in Jellyfin API points to `.strm` file (`LocationType=FileSystem`)
- BoxSet membership survives Jellyfin restart
- Playback works via Jellyfin Web and Findroid
- Purge task removes `.strm` files and cleans up directories