### PR TITLE
Fix UserConfigs GUID deserialization error and username display

### DIFF
--- a/Config/config.html
+++ b/Config/config.html
@@ -248,6 +248,7 @@
     <script type="text/javascript">
       (function () {
         const pluginId = "94EA4E14-8163-4989-96FE-0A2094BC2D6A";
+        const guidRegex = /^[0-9a-f]{32}$/i;
         // Unique ID for this IIFE instance to prevent collisions if multiple loaded
         const pageId = "gelatoConfigurationPage";
         const page = document.querySelector('#' + pageId);
@@ -318,6 +319,20 @@
         let currentConfig = null;
         let users = [];
 
+        function userConfigsArrayToObject(arr) {
+          const obj = {};
+          (arr || []).forEach(uc => {
+            if (uc.UserId && guidRegex.test(uc.UserId)) {
+              obj[uc.UserId] = {
+                Url: uc.Url,
+                MoviePath: uc.MoviePath,
+                SeriesPath: uc.SeriesPath,
+                DisableSearch: uc.DisableSearch,
+              };
+            }
+          });
+          return obj;
+        }
         async function loadCatalogs() {
           try {
             // Show loading spinner in list
@@ -563,8 +578,8 @@
           Dashboard.showLoadingMsg();
           try {
             const cfg = await window.ApiClient.getPluginConfiguration(pluginId);
+            cfg.UserConfigs = userConfigsArrayToObject(cfg.UserConfigs);
             currentConfig = cfg;
-
             // Populate fields
             if (txtUrl) txtUrl.value = cfg.Url || "";
             if (txtMoviePath) txtMoviePath.value = cfg.MoviePath || "";
@@ -641,16 +656,7 @@
             // Update local currentConfig to match
             currentConfig = cfg;
             // Re-hydrate the object form of UserConfigs for local editing
-            const savedUserConfigsArray = cfg.UserConfigs || [];
-            cfg.UserConfigs = {};
-            savedUserConfigsArray.forEach(userConfig => {
-              cfg.UserConfigs[userConfig.UserId] = {
-                Url: userConfig.Url,
-                MoviePath: userConfig.MoviePath,
-                SeriesPath: userConfig.SeriesPath,
-                DisableSearch: userConfig.DisableSearch
-              };
-            });
+            currentConfig.UserConfigs = userConfigsArrayToObject(cfg.UserConfigs);
 
             Dashboard.processPluginConfigurationUpdateResult();
           } catch (e) {
@@ -662,7 +668,7 @@
 
         async function loadUsers() {
           try {
-            users = await window.ApiClient.getUsers();
+            users = (await window.ApiClient.getUsers()).filter(u => guidRegex.test(u.Id));
             selUserConfig.innerHTML = '<option value="">-- Select user --</option>';
             users.forEach(u => {
               const opt = document.createElement('option');
@@ -691,7 +697,9 @@
 
             const infoDiv = document.createElement('div');
             infoDiv.style.flex = '1';
-            infoDiv.innerHTML = `<strong>${userName}</strong>`;
+            const strong = document.createElement('strong');
+            strong.textContent = userName;
+            infoDiv.appendChild(strong);
             container.appendChild(infoDiv);
 
             const editBtn = document.createElement('button');


### PR DESCRIPTION
**Fix UserConfigs GUID deserialization error and username display in User Overrides tab**

This PR fixes two bugs in the User Configs tab of the plugin configuration page.

**Bug 1: `Unrecognized Guid format` error when saving configuration**

When saving the plugin configuration with user overrides, Jellyfin's C# deserializer throws a `System.FormatException: Unrecognized Guid format` because `UserConfigs` was sent as an array with string user IDs, but the server-side `UserConfig.UserId` property is of type `Guid`.

The fix normalizes `UserConfigs` from array to object on load and on save, and filters out any entries whose `UserId` does not match a valid GUID format.

**Bug 2: Username displayed as `userName` instead of the actual username**

In `renderOverridesList`, using `innerHTML` with a template literal caused the variable name to be rendered literally instead of its value in some environments. Replacing it with `document.createElement('strong')` + `textContent` fixes the issue reliably.

**Changes:**
- Add `guidRegex` constant for GUID validation
- Add `userConfigsArrayToObject` helper to normalize `UserConfigs` array → object
- Convert `UserConfigs` to object on load (`loadConfig`) and after save (`saveConfig`)
- Filter users with invalid IDs in `loadUsers`
- Use `textContent` instead of `innerHTML` in `renderOverridesList`

Fixes #156