### PR TITLE
Fix live search IDs and avoid direct-playing addon URLs

### DIFF
--- a/Common.cs
+++ b/Common.cs
@@ -238,6 +238,8 @@ public static class ActionContextExtensions
         "ItemID",
     ];
 
+    private static readonly string[] UserGuidKeys = ["userId", "UserId", "UserID"];
+
     private static readonly string[] IdsGuidKeys = ["ids", "Ids", "IDs"];
 
     private static readonly HashSet<string> SearchActionNames = new(
@@ -277,13 +279,17 @@ public static class ActionContextExtensions
     )
     {
         "GetItems",
+        "GetItemById",
         "GetItem",
         "GetItemLegacy",
         "GetItemsByUserIdLegacy",
         "GetPlaybackInfo",
+        "GetPlaybackMediaSources",
         "GetPostedPlaybackInfo",
         "GetVideoStream",
+        "GetVideoStreamByContainer",
         "GetDownload",
+        "GetSubtitle",
         "GetSubtitleWithTicks",
     };
 
@@ -347,8 +353,18 @@ public static class ActionContextExtensions
             );
     }
 
-    public static bool IsInsertableAction(this ActionExecutingContext ctx) =>
-        ctx.HttpContext.IsInsertableAction();
+    public static bool IsInsertableAction(this ActionExecutingContext ctx)
+    {
+        var actionName = ctx.GetActionName();
+        if (actionName is null)
+            return ctx.HttpContext.IsInsertableAction();
+
+        return InsertableActionNames.Contains(actionName)
+            && (
+                !InsertableListActionNames.Contains(actionName)
+                || InsertableListActionNames.Contains(actionName) && ctx.IsSingleItemList()
+            );
+    }
 
     public static bool IsSingleItemList(this HttpContext ctx)
     {
@@ -448,7 +464,30 @@ public static class ActionContextExtensions
 
     public static bool TryGetUserId(this ActionExecutingContext ctx, out Guid userId)
     {
-        return ctx.HttpContext.TryGetUserId(out userId);
+        if (ctx.HttpContext.TryGetUserId(out userId))
+            return true;
+
+        foreach (var key in UserGuidKeys)
+        {
+            if (
+                ctx.ActionArguments.TryGetValue(key, out var arg)
+                && TryParseGuidValue(arg, out userId)
+            )
+            {
+                return true;
+            }
+
+            if (
+                ctx.RouteData.Values.TryGetValue(key, out var route)
+                && TryParseGuidValue(route, out userId)
+            )
+            {
+                return true;
+            }
+        }
+
+        userId = Guid.Empty;
+        return false;
     }
 
     public static bool TryGetUserId(this HttpContext ctx, out Guid userId)
@@ -463,6 +502,22 @@ public static class ActionContextExtensions
             return false;
 
         return userId != Guid.Empty;
+    }
+
+    private static bool TryParseGuidValue(object? raw, out Guid guid)
+    {
+        switch (raw)
+        {
+            case Guid g when g != Guid.Empty:
+                guid = g;
+                return true;
+            case string s when Guid.TryParse(s, out var parsed) && parsed != Guid.Empty:
+                guid = parsed;
+                return true;
+            default:
+                guid = Guid.Empty;
+                return false;
+        }
     }
 
     public static bool TryGetActionArgument<T>(

--- a/Decorators/DtoServiceDecorator.cs
+++ b/Decorators/DtoServiceDecorator.cs
@@ -88,9 +88,7 @@ public sealed class DtoServiceDecorator(IDtoService inner, Lazy<GelatoManager> m
         {
             if (dto.Path is not null && dto.Path.IsUrl())
             {
-                // dto.Path = "/stub";
-
-
+                dto.Path = "/stub";
             }
 
             dto.CanDownload = true;
@@ -107,9 +105,13 @@ public sealed class DtoServiceDecorator(IDtoService inner, Lazy<GelatoManager> m
                 {
                     foreach (var source in dto.MediaSources)
                     {
-                        //source.Path = "/stub";
-                        //source.IsRemote = false;
-                        // source.Protocol = MediaProtocol.File;
+                        source.SupportsDirectPlay = false;
+                        if (source.Path is not null && source.Path.IsUrl())
+                        {
+                            source.Path = "/stub";
+                            source.IsRemote = false;
+                            source.Protocol = MediaProtocol.File;
+                        }
                     }
                 }
                 return;

--- a/Decorators/MediaSourceManagerDecorator.cs
+++ b/Decorators/MediaSourceManagerDecorator.cs
@@ -388,12 +388,14 @@ public sealed class MediaSourceManagerDecorator(
         }
 
         // Stub path after probing is done so the real URL is never sent to clients.
-        // Force File protocol so clients proxy through Jellyfin instead of direct-playing.
-        if (ctx.GetActionName() == "GetPostedPlaybackInfo")
+        // Force File protocol so clients proxy through Jellyfin instead of direct-playing
+        // internal addon URLs like http://caddy:8088/...
+        if (ctx.GetActionName() is "GetPlaybackInfo" or "GetPostedPlaybackInfo")
         {
             selected.Path = "/stub";
             selected.IsRemote = false;
             selected.Protocol = MediaProtocol.File;
+            selected.SupportsDirectPlay = false;
         }
 
         return [selected];
@@ -525,7 +527,9 @@ public sealed class MediaSourceManagerDecorator(
             Size = item.Size,
             Type = type,
             SupportsDirectStream = true,
-            SupportsDirectPlay = true,
+            // Never direct-play Gelato HTTP URLs from clients. They may be internal Docker
+            // URLs (for example http://caddy:8088/...) and must be proxied by Jellyfin.
+            SupportsDirectPlay = false,
             // just always say yes
             HasSegments = true,
             //HasSegments = MediaSegmentManager.HasSegments(item.Id)

--- a/Filters/SearchActionFilter.cs
+++ b/Filters/SearchActionFilter.cs
@@ -173,6 +173,12 @@ public class SearchActionFilter(
             if (baseItem is null)
                 continue;
 
+            if (manager.FindExistingItem(baseItem) is { } existing)
+            {
+                dtos.Add(dtoService.GetBaseItemDto(existing, options));
+                continue;
+            }
+
             var dto = dtoService.GetBaseItemDto(baseItem, options);
             var stremioUri = StremioUri.FromBaseItem(baseItem);
             dto.Id = stremioUri.ToGuid();


### PR DESCRIPTION
## Summary

Fixes two related live-search/playback failure modes:

- live search could return a synthetic Stremio/Gelato GUID even when the item was already materialized in Jellyfin, so opening `/Items/{id}` could 404
- Gelato stream media sources were advertised as direct-playable HTTP URLs, which can leak internal addon/debrid proxy URLs to clients and make remote clients time out instead of proxying through Jellyfin

## Changes

- Prefer `manager.FindExistingItem(baseItem)` in `SearchActionFilter.ConvertMetasToDtos` and return the canonical item DTO when present.
- Resolve user id from action/route arguments in addition to claims/query params so legacy/detail routes can pass through insert/sync filters correctly.
- Include additional detail/playback/video/subtitle action names in insertable route detection.
- Mark Gelato stream media sources as `SupportsDirectPlay=false` and stub URL paths in DTO/playback responses so clients use Jellyfin as the proxy instead of trying to open addon-internal URLs directly.

## Local verification

Verified against a Jellyfin 10.11.x + Gelato 0.26.15.1 install:

- Search `matrix reloaded` returned canonical Jellyfin item id instead of synthetic id.
- Search timings remained sub-second to ~1.1s for tested queries.
- `/Users/{userId}/Items/{canonicalId}` returned 200.
- `/Items/{canonicalId}/PlaybackInfo?UserId=...` returned media source path `/stub`, `Protocol=File`, `IsRemote=false`, `SupportsDirectPlay=false`, `SupportsDirectStream=true`.
- `/Videos/{canonicalId}/stream.mkv?MediaSourceId={canonicalId}&Static=true` returned HTTP 200 and started streaming via Jellyfin.

Closes #168.
