### PR TITLE
fix: keep physical local playback outside Gelato probes

### DIFF
--- a/Decorators/MediaSourceManagerDecorator.cs
+++ b/Decorators/MediaSourceManagerDecorator.cs
@@ -187,6 +187,7 @@ public sealed class MediaSourceManagerDecorator(
         // we dont use jellyfins alternate versions crap. So we have to load it ourselves
 
         InternalItemsQuery query;
+        var associationId = item.GetProviderId("Stremio");
 
         if (item.GetBaseItemKind() == BaseItemKind.Episode)
         {
@@ -206,12 +207,20 @@ public sealed class MediaSourceManagerDecorator(
         }
         else
         {
+            var associationUri = StremioUri.FromBaseItem(item);
+            if (associationUri is null)
+            {
+                _log.LogDebug("No Stremio URI found for movie {ItemId}", item.Id);
+                return sources;
+            }
+
+            associationId = associationUri.ExternalId;
             query = new InternalItemsQuery
             {
                 IncludeItemTypes = [item.GetBaseItemKind()],
                 HasAnyProviderId = new Dictionary<string, string>
                 {
-                    { "Stremio", item.GetProviderId("Stremio") },
+                    { "Stremio", associationUri.ExternalId },
                 },
                 Recursive = false,
                 GroupByPresentationUniqueKey = false,
@@ -249,7 +258,7 @@ public sealed class MediaSourceManagerDecorator(
             "Found {s} streams. UserId={Action} GelatoId={Uri}",
             gelatoSources.Count,
             userId,
-            item.GetProviderId("Stremio")
+            associationId
         );
 
         sources.AddRange(gelatoSources);

--- a/Decorators/MediaSourceManagerDecorator.cs
+++ b/Decorators/MediaSourceManagerDecorator.cs
@@ -88,7 +88,7 @@ public sealed class MediaSourceManagerDecorator(
 
         var cfg = GelatoPlugin.Instance!.GetConfig(userId);
         if (
-            (!cfg.EnableMixed && !item.IsGelato())
+            (!cfg.EnableMixed && !IsGelatoPlaybackItem(item))
             || item.GetBaseItemKind() is not (BaseItemKind.Movie or BaseItemKind.Episode)
         )
         {
@@ -346,6 +346,13 @@ public sealed class MediaSourceManagerDecorator(
             return sources;
 
         var owner = ResolveOwnerFor(selected, item);
+        if (!IsGelatoPlaybackItem(owner))
+        {
+            return await _inner
+                .GetPlaybackMediaSources(item, user, allowMediaProbe, enablePathSubstitution, ct)
+                .ConfigureAwait(false);
+        }
+
         if (owner.IsPrimaryVersion() && owner.Id != item.Id)
         {
             sources = GetStaticMediaSources(owner, enablePathSubstitution, user);
@@ -417,6 +424,10 @@ public sealed class MediaSourceManagerDecorator(
         BaseItem ResolveOwnerFor(MediaSourceInfo s, BaseItem fallback) =>
             Guid.TryParse(s.ETag, out var g) ? libraryManager.GetItemById(g) ?? fallback : fallback;
     }
+
+    private static bool IsGelatoPlaybackItem(BaseItem item) =>
+        item.HasStreamTag()
+        || (item.Path?.StartsWith("gelato://", StringComparison.OrdinalIgnoreCase) ?? false);
 
     public Task<MediaSourceInfo> GetMediaSource(
         BaseItem item,

--- a/GelatoManager.cs
+++ b/GelatoManager.cs
@@ -407,8 +407,12 @@ public sealed class GelatoManager(
             return 0;
         }
 
-        var providerIds = video.ProviderIds;
-        providerIds.TryAdd("Stremio", uri.ExternalId);
+        var streamProviderIds = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var (providerId, value) in video.ProviderIds)
+        {
+            streamProviderIds[providerId] = value;
+        }
+        streamProviderIds["Stremio"] = uri.ExternalId;
 
         var cfg = GelatoPlugin.Instance!.GetConfig(userId);
         var stremio = cfg.Stremio;
@@ -440,7 +444,7 @@ public sealed class GelatoManager(
         var query = new InternalItemsQuery
         {
             IncludeItemTypes = [isEpisode ? BaseItemKind.Episode : BaseItemKind.Movie],
-            HasAnyProviderId = providerIds,
+            HasAnyProviderId = streamProviderIds,
             Recursive = true,
             IsDeadPerson = true,
             //  IsVirtualItem = true,
@@ -524,7 +528,7 @@ public sealed class GelatoManager(
                 locked.Add(MetadataField.Tags);
             streamItem.LockedFields = locked.ToArray();
 
-            streamItem.ProviderIds = providerIds;
+            streamItem.ProviderIds = streamProviderIds;
             streamItem.RunTimeTicks = video.RunTimeTicks ?? video.RunTimeTicks;
             streamItem.LinkedAlternateVersions = [];
             streamItem.SetPrimaryVersionId(null);


### PR DESCRIPTION
## Summary

Closes #189.

`SyncStreams` copies the `Stremio` provider ID to a primary local item. Playback then uses `IsGelato()`, which treats that metadata ID as Gelato playback ownership and can send the physical local source through Gelato's probe path.

This change keeps the existing metadata behavior but uses playback-specific ownership:

- Gelato stream items are identified by the existing `gelato-stream` tag.
- Inserted Gelato items are identified by their existing `gelato://` path.
- Physical local items delegate to Jellyfin when mixed libraries are disabled.
- With mixed libraries enabled, a selected physical local owner also delegates to Jellyfin; selected Gelato streams keep the existing playback path.

No Gelato stream protocol, probing, stubbing, user resolution, or CI behavior is changed.

## Validation

- `dotnet build Gelato.sln --configuration Release`: succeeded with 0 errors.
- `dotnet format Gelato.sln --verify-no-changes --no-restore`: clean.
- The exact submitted commit (`2e4412e`) was built and deployed on Jellyfin 10.11.11. The reproduced physical local title returned one native `File` source (`IsRemote=false`, no stub); its HLS playlist and segment returned HTTP 200, and Jellyfin Web playback advanced.
- A remote Gelato fixture still returned one source with HTTP 200 playback info and advanced in Jellyfin Web.
