### PR TITLE
fix: keep search results when a meta has a blank imdb_id

### DIFF
--- a/GelatoManager.cs
+++ b/GelatoManager.cs
@@ -1437,7 +1437,26 @@ public sealed class GelatoManager(
         if (!string.IsNullOrWhiteSpace(meta.ImdbId))
             item.SetProviderId(MetadataProvider.Imdb, meta.ImdbId);
 
-        var stremioUri = new StremioUri(meta.Type, meta.ImdbId ?? id);
+        // Fall back to the catalog id when ImdbId is absent OR blank. Addons
+        // commonly emit "imdb_id": "" rather than omitting the field, and `??`
+        // does not treat an empty string as missing - so a meta carrying a
+        // perfectly good id (e.g. "tmdb:456173") reached StremioUri with "".
+        var externalId = !string.IsNullOrWhiteSpace(meta.ImdbId) ? meta.ImdbId : id;
+
+        // Every caller of IntoBaseItem already skips a null return, so honour
+        // that contract instead of throwing: an exception here aborts the whole
+        // request and takes every other result with it.
+        if (string.IsNullOrWhiteSpace(externalId))
+        {
+            _log.LogWarning(
+                "Skipping meta with no usable external id: {Name} ({Type})",
+                meta.GetName(),
+                meta.Type
+            );
+            return null;
+        }
+
+        var stremioUri = new StremioUri(meta.Type, externalId);
         item.SetProviderId("Stremio", stremioUri.ExternalId);
 
         item.Overview = meta.Description ?? meta.Overview;


### PR DESCRIPTION
Fixes #195.

A single search result with `"imdb_id": ""` aborted the entire `/Items` response
— 12 results found, 0 returned.

`IntoBaseItem` built its `StremioUri` with `meta.ImdbId ?? id`. `??` falls back
only on `null`, not on an empty string, so a meta carrying a perfectly usable
catalog id reached `StremioUri` with `""` and hit its `ArgumentException` guard.
Three lines above, the same method already uses `IsNullOrWhiteSpace` for the same
field.

Observed with AIOStreams against plain TMDB: searching `minecraft` returns 12
metas, two with `"imdb_id": ""` and ids `tmdb:456173` / `tmdb:98545`. Both are
already mapped to `MetadataProvider.Tmdb` a few lines earlier, so the identifier
needed was present and simply not reached — which is why this falls back rather
than skipping, and keeps the two results.

It also returns `null` instead of throwing when nothing usable exists. Every
caller of `IntoBaseItem` already handles `null` by skipping — `SearchActionFilter`,
`InsertActionFilter`, and four sites in `GelatoManager` including two episode
loops — so throwing violated a contract the whole codebase implements. In those
loops the same record would abort a season or series import, not just a search.

The skip is logged at Warning so silent data loss cannot happen without it being
visible in normal logs.

Same shape as #141.
